### PR TITLE
Export isExe() & file permission even without gid and uid

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,12 @@ const isExe = (mode, gid, uid) => {
 	if (process.platform === 'win32') {
 		return true;
 	}
+	const isGroup = gid ? process.getgid && gid === process.getgid() : true;
+	const isUser = uid ? process.getuid && uid === process.getuid() : true;
 
 	return Boolean((mode & parseInt('0001', 8)) ||
-		(mode & parseInt('0010', 8)) && process.getgid && gid === process.getgid() ||
-		(mode & parseInt('0100', 8)) && process.getuid && uid === process.getuid());
+		((mode & parseInt('0010', 8)) && isGroup) ||
+		((mode & parseInt('0100', 8)) && isUser));
 };
 
 module.exports = name => {
@@ -29,3 +31,5 @@ module.exports.sync = name => {
 
 	return stats && stats.isFile() && isExe(stats.mode, stats.gid, stats.uid);
 };
+
+module.exports.checkMode = isExe;

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,21 @@ Type: `string`
 
 Path of the file.
 
+### executable.checkMode(mode, gid, uid)
+
+Returns a boolean of whether the mode passed as first argument means that the file is executable.
+
+#### mode
+
+Type: `number`
+
+Property `mode` of `fs.Stats` instance returned by `fs.stat()` (or `fs.statSync()``) function.
+
+#### gid, uid
+
+Type: `number`
+
+Respectively the group identity and user identity of the file. If not set, permissions will be evaluated without considering owner or group of the file.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Type: `string`
 
 Path of the file.
 
-### executable.checkMode(mode, gid, uid)
+### executable.checkMode(mode, [gid], [uid])
 
 Returns a boolean of whether the mode passed as first argument means that the file is executable.
 
@@ -46,7 +46,7 @@ Returns a boolean of whether the mode passed as first argument means that the fi
 
 Type: `number`
 
-Property `mode` of `fs.Stats` instance returned by `fs.stat()` (or `fs.statSync()``) function.
+Property `mode` of `fs.Stats` instance returned by `fs.stat()` (or `fs.statSync()`) function.
 
 #### gid, uid
 


### PR DESCRIPTION
Hi :)
This PR refers to issue #9.
I've made two changes:
- Exported function `isExe()` as `checkMode()`
- Maked _gid_ and _uid_ of `isExe()` optional: if not setted the file permissions will be evaluated regardless the match between process and file owner and group.

I hope you like it: I think that this changes makes your module even more flexible and powerful :)