### PR TITLE
Update pify to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "permission"
   ],
   "dependencies": {
-    "pify": "^2.2.0"
+    "pify": "^3.0.0"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
Since `executable` already requires Node.js 4, this is only needs a minor release.